### PR TITLE
update to support dear-imgui 1.2.2 ; additional arguments to childWindow

### DIFF
--- a/dear-imgui-reflex.cabal
+++ b/dear-imgui-reflex.cabal
@@ -24,11 +24,11 @@ source-repository head
 
 common common-options
   build-depends:
-    , base                    ^>=4.13.0.0
+    , base                    >=4.13
     , bytestring
     , constraints
     , constraints-extras
-    , dear-imgui
+    , dear-imgui              >= 1.2.2
     , exception-transformers
     , dependent-map
     , dependent-sum

--- a/examples/example/Main.hs
+++ b/examples/example/Main.hs
@@ -172,7 +172,7 @@ app win = do
   (_, dynActions) <- runDynamicWriterT guest
   performEvent_ $
     ffor (updated dynActions) $ \actions -> do
-      sequence_ [untilNothingM pollEventWithImGui, openGL3NewFrame, sdl2NewFrame win, newFrame]
+      sequence_ [untilNothingM pollEventWithImGui, openGL3NewFrame, sdl2NewFrame, newFrame]
       sequence_ actions
       sequence_ [glClear GL_COLOR_BUFFER_BIT, render, openGL3RenderDrawData =<< getDrawData, glSwapWindow win]
   where
@@ -197,7 +197,7 @@ guest = do
     ffor eC $
       const
         ( window "There was a click!" $ do
-            childWindow "And?" $ do
+            childWindow (pure $ defaultImGuiWindowConfig { name = "And?" }) $ do
               text "See how we react?"
               separator $ pure ()
               selectionE <- comboFromBoundedEnum @ASum "A multi-select" "ASum value" show

--- a/src/Reflex/DearImGui/Types.hs
+++ b/src/Reflex/DearImGui/Types.hs
@@ -130,15 +130,27 @@ window tD child = do
   commitAction $ ffor (zipDyn' tD tickD) (const DearImGui.end)
   pure child'
 
+data ImGuiWindowConfig = ImGuiWindowConfig { name   :: String
+                                           , size   :: !DearImGui.ImVec2
+                                           , border :: !Bool
+                                           , flags  :: !DearImGui.ImGuiWindowFlags
+                                           }
+                       deriving stock (Show)
+
+defaultImGuiWindowConfig :: ImGuiWindowConfig
+defaultImGuiWindowConfig =
+  ImGuiWindowConfig "Child" (DearImGui.ImVec2 0 0) True DearImGui.ImGuiWindowFlags_None
+
+
 -- | Wraps `DearImgui.beginChild` and `DearImgui.endChild`
 childWindow ::
   ( ImGuiSDLReflex t m
   ) =>
-  Dynamic t String ->
+  Dynamic t ImGuiWindowConfig ->
   m a ->
   m a
 childWindow tD child = do
-  commitAction $ ffor tD (void . DearImGui.beginChild)
+  commitAction $ ffor tD (\(ImGuiWindowConfig n s b fs) -> void $ DearImGui.beginChild n s b fs)
   child' <- child -- see the comment on `window`
   commitAction $ ffor tD (const DearImGui.endChild)
   pure child'


### PR DESCRIPTION
Cool project! It seems that this no longer builds with the latest version of dear-imgui available on hackage. The PR provides two fixes that allow it to compile again.  I did introduce some new intermediate "config" data type to pass newChildWindow since that seemed more reasonable than have 5 arguments, but if you rather have separate arguments that can be refactored.